### PR TITLE
fix: disable while loading session

### DIFF
--- a/lua/nvim-rooter.lua
+++ b/lua/nvim-rooter.lua
@@ -28,6 +28,10 @@ local function match(dir, pattern)
 end
 
 local function activate()
+  if vim.g.SessionLoad == 1 then
+    return false
+  end
+
   if _config.exclude_filetypes[vim.bo.filetype] ~= nil then
     return false
   end


### PR DESCRIPTION
Currently, `nvim-rooter` is active even when Neovim is loading sessions.  
The problem is that files are recorded as relative paths in session files (surprisingly so).  
If a file from another project is included in the project, it'll change the cwd in the middle of loading the session and mess up the loading of other files because the base path has been changed.

This patch simply adds a check that tests if global variable `SessionLoad` is set.  
(see `:h SessionLoad-variable`)