### PR TITLE
change to parent if no root

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ require('nvim-rooter').setup {
   rooter_patterns = { '.git', '.hg', '.svn' },
   trigger_patterns = { '*' },
   manual = false,
+  fallback_to_parent = false,
 }
 ```
 
@@ -79,6 +80,12 @@ filetype of the current buffer.
 
 ```vim
 lua require('nvim-rooter').setup { exclude_filetypes = { 'python', 'lua' } }
+```
+
+Change to the directory of the file when it has no root
+
+```vim
+lua  require('nvim-rooter').setup { fallback_to_parent = true }
 ```
 
 ## Comparison

--- a/lua/nvim-rooter.lua
+++ b/lua/nvim-rooter.lua
@@ -81,6 +81,11 @@ local function rooter()
 
   if root ~= nil then
     change_dir(root)
+  else
+    local parent = parent_dir(vim.api.nvim_buf_get_name(0))
+    if vim.fn.getcwd() ~= parent then
+      change_dir(parent)
+    end
   end
 end
 

--- a/lua/nvim-rooter.lua
+++ b/lua/nvim-rooter.lua
@@ -9,6 +9,7 @@ local _config = {
     ['dashboard'] = true,
     ['TelescopePrompt'] = true,
   },
+  fallback_to_parent = false,
 }
 
 local function parent_dir(dir)
@@ -81,7 +82,7 @@ local function rooter()
 
   if root ~= nil then
     change_dir(root)
-  else
+  elseif _config.fallback_to_parent then
     local parent = parent_dir(vim.api.nvim_buf_get_name(0))
     if vim.fn.getcwd() ~= parent then
       change_dir(parent)
@@ -139,6 +140,7 @@ local function setup(opts)
     or { '.git', '.hg', '.svn' }
   _config.trigger_patterns = opts.trigger_patterns ~= nil and opts.trigger_patterns or { '*' }
   _config.exclude_filetypes = merge(_config.exclude_filetypes, opts.exclude_filetypes)
+  _config.fallback_to_parent = opts.fallback_to_parent ~= nil and opts.fallback_to_parent
 
   if opts.manual == nil or opts.manual == false then
     setup_autocmd()


### PR DESCRIPTION
I often open files from my startup screen so my working directory often is different from the parent directory  of the opened file. If the opened file has no root, I would like to fall back to the parent directory of in order to execute commands there.
I was wondering if this is a behavior that is generally desirable as a fallback if a file has no root?