### PR TITLE
Add RooterTo feature

### DIFF
--- a/plugin/nvim-rooter.lua
+++ b/plugin/nvim-rooter.lua
@@ -6,8 +6,11 @@ vim.g.loaded_nvim_rooter = 1
 local cmd = vim.api.nvim_create_user_command
 
 cmd('Rooter', function()
-  require('nvim-rooter').rooter()
+  require('nvim-rooter').rooter_default()
 end, {})
+cmd('RooterTo', function(opts)
+  require('nvim-rooter').rooter_custom({opts.fargs[1]})
+end, {nargs = 1})
 cmd('GetRootDir', function()
   require('nvim-rooter').get_root()
 end, {})


### PR DESCRIPTION
This function allows the user to pick a specific pattern to find the root.

### Example

Given the following configuration:
```lua
config = function()
  require('nvim-rooter').setup {
    rooter_patterns = { '=src' }
  }
end
 ```

And the following project tree:
```
project
├── .git
├── src
│   ├── src1.c
│   └── src2.c
└── tests
    ├── test1.c
    └── test2.c
```

While the user is developing, he can use the `projects/src` as the root. Later, change it to `project` by running `:RooterTo .git` to eassily access the `projects/tests` files.
