### PR TITLE
fix: can get the root of the new file and filetypeless file now (close #18)

### DIFF
--- a/lua/nvim-rooter.lua
+++ b/lua/nvim-rooter.lua
@@ -2,7 +2,6 @@ local _config = {
   patterns = {},
   trigger_patterns = {},
   exclude_filetypes = {
-    [''] = true,
     ['help'] = true,
     ['nofile'] = true,
     ['NvimTree'] = true,
@@ -54,6 +53,7 @@ local function get_root(patterns)
   -- don't need to resove sybolic links explicitly, because
   -- `nvim_buf_get_name` returns the resolved path.
   local current = vim.api.nvim_buf_get_name(0)
+  current = current == "" and vim.fn.getcwd() or current
   local parent = parent_dir(current)
 
   while 1 do


### PR DESCRIPTION
Well, I think the behaviour that this plugin doesn't work in new file and filetypeless file now is a bug.