### PR TITLE
feat: add option to change the scope of working directory change

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ require('nvim-rooter').setup {
   trigger_patterns = { '*' },
   manual = false,
   fallback_to_parent = false,
+  cd_scope = "global",
 }
 ```
 
@@ -87,6 +88,18 @@ Change to the directory of the file when it has no root
 
 ```vim
 lua  require('nvim-rooter').setup { fallback_to_parent = true }
+```
+
+Change the scope of working directory change. The supported values are:
+
+- `global` (default): Changes global cwd with `vim.api.nvim_set_current_dir()`
+- `window`: Changes window-local cwd with `:lcd`
+- `tabpage`: Changes tabpage-local cwd with `:tcd`
+- `smart`: If local cwd is already set, changes local cwd.
+  If not, changes global cwd. Check `:h chdir()` for more detail.
+
+```vim
+lua require('nvim-rooter').setup { cd_scope = "window" }
 ```
 
 ## Comparison

--- a/lua/nvim-rooter.lua
+++ b/lua/nvim-rooter.lua
@@ -16,7 +16,13 @@ local function parent_dir(dir)
 end
 
 local function change_dir(dir)
-  vim.api.nvim_set_current_dir(dir)
+  local cd_method = {
+    global = vim.api.nvim_set_current_dir,
+    window = vim.cmd.lcd,
+    tabpage = vim.cmd.tcd,
+    smart = vim.fn.chdir,
+  }
+  cd_method[_config.cd_scope](dir)
 end
 
 local function match(dir, pattern)
@@ -158,6 +164,7 @@ local function setup(opts)
   _config.trigger_patterns = opts.trigger_patterns ~= nil and opts.trigger_patterns or { '*' }
   _config.exclude_filetypes = merge(_config.exclude_filetypes, opts.exclude_filetypes)
   _config.fallback_to_parent = opts.fallback_to_parent ~= nil and opts.fallback_to_parent
+  _config.cd_scope = opts.cd_scope ~= nil and opts.cd_scope or "global"
 
   if opts.manual == nil or opts.manual == false then
     setup_autocmd()


### PR DESCRIPTION
<https://github.com/airblade/vim-rooter?tab=readme-ov-file#miscellaneous>
`vim-rooter` supports `g:rooter_cd_cmd` to select the command used for changing working directory (`:cd`, `:lcd`, `:tcd`).

Likewise, I've added `cd_scope` option to the `setup()`.

```lua
local function change_dir(dir)
  local cd_method = {
    global = vim.api.nvim_set_current_dir,
    window = vim.cmd.lcd,
    tabpage = vim.cmd.tcd,
    smart = vim.fn.chdir,
  }
  cd_method[_config.cd_scope](dir)
end
```

The updated `change_dir()` function should speak for itself.