### PR TITLE
feat: don't change root if cwd matches pattern(s)

### DIFF
--- a/lua/nvim-rooter.lua
+++ b/lua/nvim-rooter.lua
@@ -33,6 +33,15 @@ local function match(dir, pattern)
   end
 end
 
+local function matches(dir, patterns)
+  for _, pattern in ipairs(patterns) do
+    if match(dir, pattern) then
+      return true
+    end
+  end
+  return false
+end
+
 local function activate()
   if vim.g.SessionLoad == 1 then
     return false
@@ -62,13 +71,17 @@ local function get_root(patterns)
   current = current == "" and vim.fn.getcwd() or current
   local parent = parent_dir(current)
 
+  -- start by checking the current directory, if it matches we finish early.
+  if matches(current, patterns) then
+    return current
+  end
+
   while 1 do
-    for _, pattern in ipairs(patterns) do
-      if match(parent, pattern) then
-        return parent
-      end
+    if matches(parent, patterns) then
+      return parent
     end
 
+    -- go up a level
     current, parent = parent, parent_dir(parent)
     if parent == current then
       break


### PR DESCRIPTION
A use-case I meet very often is having git repositories inside one another, for example:
```
test
├── .git
└── test-inside
    └── .git
```

Currently, when opening a file inside the `test-inside` folder, the root will change to the parent repository, without taking into account if the current working directory matches. I would enjoy a feature where I don't change to the parent directory if the current directory already matches.

I feel this should be expected behavior, but I am not opposed to hide this behavior behind an opt-in configuration variable.

